### PR TITLE
Use latest version of open-webui (name change)

### DIFF
--- a/docker-compose-ollama-gpu.yaml
+++ b/docker-compose-ollama-gpu.yaml
@@ -37,7 +37,7 @@ services:
               capabilities: [gpu]
 
   ollama-webui:
-    image: ghcr.io/ollama-webui/ollama-webui:main
+    image: ghcr.io/open-webui/open-webui:main
     container_name: ollama-webui
     volumes:
       - ./ollama/ollama-webui:/app/backend/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - ollama-docker
 
   ollama-webui:
-    image: ghcr.io/ollama-webui/ollama-webui:main
+    image: ghcr.io/open-webui/open-webui:main
     container_name: ollama-webui
     volumes:
       - ./ollama/ollama-webui:/app/backend/data


### PR DESCRIPTION
The `ollama-webui` project appears to have changed name to `open-webui` - see https://github.com/open-webui/open-webui/discussions/602

The new project is actively developed and the new container has some additional features and fixes.

This PR changes the container pulled, but leaves the Compose service name or volume directory names as `ollama-webui`.
This means existing installation *might* [migrate automatically](https://docs.openwebui.com/migration). Later, it's probably worth changing the service name and data directory to `open-webui` to save confusion.