### PR TITLE
Changed README WebUI example port to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ else
 docker-compose up -d
 ```
 
-Visit [http://localhost:8000](http://localhost:8000) in your browser to access Ollama-webui.
+Visit [http://localhost:8080](http://localhost:8080) in your browser to access Ollama-webui.
 
 ### Model Installation
 


### PR DESCRIPTION
Changed README WebUI example port to 8080 So it coincides with the current dockerfile configuration.