### PR TITLE
Fix Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,25 @@
-FROM python:3.14-slim
+FROM python:3.12-slim
 
-WORKDIR /code 
+# Prevents Python from writing .pyc files & forces unbuffered logs
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
 
-COPY ./requirements.txt ./
+WORKDIR /code
+COPY ./requirements.txt .
 
-RUN apt-get update && apt-get install git -y && apt-get install curl -y
+# Install minimal build deps in one layer; clean apt cache
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc g++ make cmake pkg-config git curl \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir -r requirements.txt
+# Upgrade build tooling, then install deps
+RUN python -m pip install --upgrade pip setuptools wheel \
+ && pip install -r requirements.txt
 
+# Copy app code
 COPY ./src ./src
 
 EXPOSE 8000
-
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]


### PR DESCRIPTION
Build fails because the image lacks a C/C++ toolchain and several deps don’t have wheels for Python 3.14 yet (uvloop, lz4, hnswlib, duckdb). Easiest path: move to Python 3.12 (or 3.11) where wheels exist.